### PR TITLE
docs: update demo to use svg-toolbelt@0.7.0

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -127,7 +127,7 @@
           <span class="text-white font-bold text-sm">🧰</span>
         </div>
         <h1 class="text-xl font-bold text-gray-900">SVG Toolbelt</h1>
-        <span class="hidden sm:inline-block bg-blue-100 text-blue-800 text-xs font-medium px-2.5 py-0.5 rounded-full">v0.6.1</span>
+        <span class="hidden sm:inline-block bg-blue-100 text-blue-800 text-xs font-medium px-2.5 py-0.5 rounded-full">v0.7.0</span>
       </div>
       <div class="flex items-center space-x-4">
         <a href="#features" class="hidden md:block text-gray-600 hover:text-gray-900">Features</a>
@@ -259,7 +259,7 @@
       <div id="loading" class="text-center py-12">
         <div class="inline-flex items-center space-x-2">
           <div class="w-8 h-8 border-4 border-gitlab-200 border-t-gitlab-500 rounded-full animate-spin"></div>
-          <span class="text-gray-600">Loading SVG Toolbelt v0.6.1 from CDN…</span>
+          <span class="text-gray-600">Loading SVG Toolbelt v0.7.0 from CDN…</span>
         </div>
       </div>
 
@@ -785,7 +785,7 @@
 
   <!-- JavaScript: Load SVG Toolbelt from CDN and initialize demos -->
   <script type="module">
-    import { SvgZoom, initializeSvgZoom } from 'https://cdn.jsdelivr.net/npm/svg-toolbelt@0.6.1/dist/svg-toolbelt.esm.js';
+    import { SvgZoom, initializeSvgZoom } from 'https://cdn.jsdelivr.net/npm/svg-toolbelt@0.7.0/dist/svg-toolbelt.esm.js';
 
     let currentInstances = [];
 


### PR DESCRIPTION
## 🚀 Auto-generated PR: Update Demo Site

This PR updates the demo site to use the latest published version of svg-toolbelt.

### Changes
- Updated `docs/index.html` to reference `svg-toolbelt@0.7.0`
- Ensures demo site uses the latest published package version

### Context
- Triggered by release: v0.7.0
- Published package: https://www.npmjs.com/package/svg-toolbelt

This PR can be merged automatically or reviewed first based on your preferences.